### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduled-reservations.yml
+++ b/.github/workflows/scheduled-reservations.yml
@@ -1,5 +1,7 @@
 ---
 name: Scheduled Reservation
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/scheduled-reservations.yml
+++ b/.github/workflows/scheduled-reservations.yml
@@ -1,12 +1,13 @@
 ---
 name: Scheduled Reservation
-permissions:
-  contents: read
 
 on:
   schedule:
     - cron: "53 21 * * *" # 21:53 UTC (5:53pm EST)
   workflow_dispatch: # Allow manual runs
+
+permissions:
+  contents: read
 
 jobs:
   run-reservations:


### PR DESCRIPTION
Potential fix for [https://github.com/Amet13/ODYSSEY/security/code-scanning/1](https://github.com/Amet13/ODYSSEY/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow (just below the `name:` key and above `on:`), so it applies to all jobs unless overridden. Since this workflow only checks out code and uploads artifacts (and does not appear to require any write access to the repository), the minimal permission required is `contents: read`. This change does not affect the workflow's existing functionality and ensures the `GITHUB_TOKEN` used by the workflow has the least privilege necessary.

**What to change:**  
- In `.github/workflows/scheduled-reservations.yml`, add the following block after the `name:` line (line 2), before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
